### PR TITLE
release-drafter update

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
 
 permissions:
   contents: write
@@ -19,5 +19,6 @@ jobs:
         with:
           disable-releaser: github.ref != 'refs/heads/main'
           config-name: release-drafter.yml
+          commitish: main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,10 +7,6 @@ on:
       - main
   pull_request_target:
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**What this PR does / why we need it**:
Replace release-drafter workflow trigger `pull_request` with `pull_request_target`. This is needed due to lack of permissions granted for github token when PR is created from fork of the repository.