### PR TITLE
update size-label

### DIFF
--- a/.github/workflows/size-labels.yaml
+++ b/.github/workflows/size-labels.yaml
@@ -1,6 +1,9 @@
 name: 'Assign size labels to PRs'
 
-on: [workflow_dispatch, pull_request]
+on:
+  workflow_dispatch:
+  pull_request_target:
+
 
 permissions:
   contents: read

--- a/.github/workflows/size-labels.yaml
+++ b/.github/workflows/size-labels.yaml
@@ -4,11 +4,6 @@ on:
   workflow_dispatch:
   pull_request_target:
 
-
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   size-label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**What this PR does / why we need it**:
Replace size-label workflow trigger `pull_request` with `pull_request_target`. This is needed due to lack of permissions granted for github token when PR is created from fork of the repository.
